### PR TITLE
Fix identical machine-ids causing dhcp servers to to use same IPs

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -8,6 +8,11 @@ apt-add-repository --remove ppa:ansible/ansible
 apt autoremove
 apt update
 
+#  Blank netplan machine-id (DUID) so machines get unique ID generated on boot.
+truncate -s 0 /etc/machine-id
+rm /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+
 # Delete unneeded files.
 rm -f /home/vagrant/*.sh
 


### PR DESCRIPTION
This took me a long time to finally figure out! For a few years now I've been using Vagrants DHCP feature to assign IPs to VMs,  but about a year ago (since https://github.com/geerlingguy/packer-drupal-vm/commit/f389b8e4c65c1f06a94663fe2e92a64c2597ca33 i guess), all VMs started getting the same IP.

As it turns out this is because Ubuntu 18.04 changed how it identifies itself to DHCP servers, using machine-ids instead of mac addresses. There's quite a few reports on this if you search for ["truncate -s 0 /etc/machine-id"](https://www.google.com/search?q=%22truncate+-s+0+%2Fetc%2Fmachine-id%22&oq=%22truncate+-s+0+%2Fetc%2Fmachine-id%22)

I'm not sure this is the correct fix but it's inspired by [Google](https://docs.vmware.com/en/VMware-Cloud-Assembly/services/Using-and-Managing/GUID-57D5D20B-B613-4BDE-A19F-223719F0BABB.html) [search](https://blog.programster.org/fix-ubuntu-18-04-vm-guests-all-getting-the-same-ip) [results](https://jaylacroix.com/fixing-ubuntu-18-04-virtual-machines-that-fight-over-the-same-ip-address/). Packer [example](https://github.com/hashicorp/packer/blob/21287fee58ce67e0da389f5b8e987eb081a6b93f/examples/hcl/linux/etc/scripts/100-cleanup.sh#L73:L74) does it a bit simpler but not sure.

I've verified that if I run this on an existing VM, it's DHCP assigned IP finally becomes unique

```
sudo rm -f /etc/machine-id
sudo dbus-uuidgen --ensure=/etc/machine-id
sudo rm /var/lib/dbus/machine-id
sudo ln -s /etc/machine-id /var/lib/dbus/machine-id

exit
vagrant halt; vagrant up
```

I had a PR open to Drupal VM for DHCP https://github.com/geerlingguy/drupal-vm/pull/1559 but nowadays I just [patch](https://github.com/geerlingguy/drupal-vm/commit/69dd5a15c056e6d1b622b6b2333680dc2b2658c3.patch) it with composer-patches.