### PR TITLE
Fix deprecated ansible variable definition causing drupal to be installed in base box

### DIFF
--- a/drupal-vm.json
+++ b/drupal-vm.json
@@ -24,7 +24,7 @@
       "playbook_file": "drupal-vm/provisioning/playbook.yml",
       "extra_arguments": [
         "--extra-vars",
-        "drupal_build_composer_project=False drupal_install_site=False configure_drush_aliases=False"
+        "{\"drupal_build_composer_project\":false,\"drupal_install_site\":false,\"configure_drush_aliases\":false}"
       ],
       "user": "vagrant"
     },


### PR DESCRIPTION
Not sure why #5 fails but it shouldn't run in the first place.

Since Ansible `v2.12` these variables were ignored since they weren't cast as booleans correctly.

According to https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#key-value-format

> Values passed in using the key=value syntax are interpreted as strings. Use the JSON format if you need to pass non-string values such as Booleans, integers, floats, lists, and so on.